### PR TITLE
Add tags and categories to front page post listings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,13 @@
+{
+  "plugins": ["prettier-plugin-go-template"],
+  "overrides": [
+    {
+      "files": ["*.html"],
+      "options": {
+        "parser": "go-template",
+        "goTemplateBracketSpacing": true,
+        "bracketSameLine": true
+      }
+    }
+  ]
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -6,6 +6,9 @@
 
 :root {
   --accent-color: rgb(5, 150, 105);
+  --font-family-headings: "Cormorant Garamond", serif;
+  --letter-spacing-headings: 0.06em;
+  --font-weight-headings: 700;
 }
 
 .dark {
@@ -20,9 +23,9 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Cormorant Garamond", serif;
-  letter-spacing: 0.06em;
-  font-weight: 700;
+  font-family: var(--font-family-headings);
+  letter-spacing: var(--letter-spacing-headings);
+  font-weight: var(--font-weight-headings);
 }
 
 /* ======= Link hover styles ======= */
@@ -35,11 +38,31 @@ a:hover {
   color: var(--accent-color);
 }
 
-/* ======= Single Post overried styles ======= */
+/* ======= Post list overried styles ======= */
 
-.single-summary {
-  font-size: 1rem;
+.post-line {
+  margin-bottom: var(--h1-margin-bottom);
+
+  a {
+    text-decoration-skip-ink: all;
+  }
+
+  .line-title {
+    margin-bottom: calc(var(--p-margin-bottom) * 0.25);
+  }
+
+  .category-tags {
+    font-size: small;
+    font-family: var(--font-family-body);
+    margin: 0.5rem 0;
+  }
+
+  .line-summary {
+    font-family: var(--font-family-body);
+  }
 }
+
+/* ======= Single Post overried styles ======= */
 
 .single-subsummary {
   font-size: 1rem;

--- a/html-improvement-recommendations.md
+++ b/html-improvement-recommendations.md
@@ -1,0 +1,126 @@
+# HTML Structure Improvement Recommendations
+
+Based on analysis of the Hugo site at http://localhost:1313, here are the key issues and recommendations for improving HTML structure, accessibility, and best practices.
+
+## Critical Issues
+
+### 1. **Multiple H1 Tags** ✗
+**Issue:** There are two H1 tags on the homepage:
+- "Carl's Blog" (header/banner)
+- "Latest posts" (main content)
+
+**Fix:** Use proper heading hierarchy:
+- `<h1>Carl's Blog</h1>` (site title, keep as H1)
+- `<h2>Latest posts</h2>` (section heading, change to H2)
+
+### 2. **Navigation Structure** ✗
+**Issue:** Navigation links are wrapped in `<p>` tags instead of proper navigation markup.
+
+**Fix:** Use semantic navigation:
+```html
+<nav aria-label="Main navigation">
+  <ul>
+    <li><a href="/">Home</a></li>
+    <li><a href="/posts">Posts</a></li>
+    <li><a href="/categories">Categories</a></li>
+    <li><a href="/tags">Tags</a></li>
+  </ul>
+</nav>
+```
+
+### 3. **Generic Containers** ✗
+**Issue:** Many `<div>` elements should be semantic HTML5 elements.
+
+**Fix:** Use semantic structure:
+```html
+<article> <!-- for each blog post -->
+  <header>
+    <h3><a href="...">Post Title</a></h3>
+    <time datetime="2025-07-02">Jul 2, 2025</time>
+  </header>
+  <p>Post excerpt...</p>
+  <footer>
+    <span>Category: <a href="...">TIL</a></span>
+    <span>Tags: <a href="...">#claude-code</a>, ...</span>
+  </footer>
+</article>
+```
+
+## Accessibility Improvements
+
+### 4. **Missing ARIA Labels**
+**Fix:** Add proper labeling for screen readers:
+```html
+<nav aria-label="Main navigation">
+<main aria-label="Blog posts">
+<section aria-labelledby="latest-posts">
+  <h2 id="latest-posts">Latest posts</h2>
+```
+
+### 5. **Proper Time Elements**
+**Fix:** Use `<time>` elements with `datetime` attributes:
+```html
+<time datetime="2025-07-02">Jul 2, 2025</time>
+```
+
+### 6. **Skip Links**
+**Fix:** Add skip navigation for keyboard users:
+```html
+<a href="#main-content" class="skip-link">Skip to main content</a>
+```
+
+## Content Structure Improvements
+
+### 7. **Post Entries as Articles**
+**Fix:** Each blog post should be an `<article>` with proper structure:
+```html
+<article>
+  <header>
+    <h3><a href="...">Post Title</a></h3>
+    <time datetime="...">Date</time>
+  </header>
+  <p>Post summary</p>
+  <footer>
+    <p>Filed under: <a href="...">Category</a></p>
+    <p>Tags: <a href="...">tag1</a>, <a href="...">tag2</a></p>
+  </footer>
+</article>
+```
+
+### 8. **Proper List Structure for Posts**
+**Fix:** Wrap post entries in a list:
+```html
+<section aria-labelledby="latest-posts">
+  <h2 id="latest-posts">Latest posts</h2>
+  <ol> <!-- or <ul> if order doesn't matter -->
+    <li><article>...</article></li>
+    <li><article>...</article></li>
+  </ol>
+</section>
+```
+
+## SEO and Meta Improvements
+
+### 9. **Meta Description**
+**Fix:** Ensure each page has a proper meta description.
+
+### 10. **Structured Data**
+**Fix:** Consider adding JSON-LD structured data for blog posts.
+
+## Implementation Priority
+
+1. **High Priority:** Fix multiple H1 tags (change "Latest posts" to H2)
+2. **High Priority:** Convert navigation to semantic `<nav>` structure
+3. **Medium Priority:** Use `<article>` elements for blog posts
+4. **Medium Priority:** Add proper `<time>` elements
+5. **Low Priority:** Add ARIA labels and skip links
+
+## Files to Modify
+
+Since this is a Hugo site using the Typo theme, the main template files to modify are likely:
+- `themes/typo/layouts/_default/baseof.html` (base template)
+- `themes/typo/layouts/_default/list.html` (homepage/list template)
+- `themes/typo/layouts/partials/header.html` (header/navigation)
+- `themes/typo/layouts/partials/post-entry.html` (individual post entries)
+
+**Note:** The most critical fix is changing "Latest posts" from H1 to H2 to establish proper heading hierarchy. This will significantly improve accessibility and SEO compliance.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 baseURL: "https://cstalhem.github.io"
 languageCode: "en-us"
-title: "My Personal Blog"
+title: "Carl's Blog"
 theme: "typo"
 timeZone: "Europe/Stockholm"
 
@@ -10,11 +10,11 @@ params:
   colorPalette: "default"
   homeIntroTitle: ""
   homeIntroContent: ""
-  homeCollectionTitle: "Posts"
+  homeCollectionTitle: "Latest posts"
   homeCollection: "posts"
-  paginationSize: 15
+  paginationSize: 10
   listSummaries: true
-  listDateFormat: "2 Jan 2006"
+  listDateFormat: "Jan 2, 2006"
   breadcrumbs:
     enabled: true
     showCurrentPage: false

--- a/layouts/partials/post-entry.html
+++ b/layouts/partials/post-entry.html
@@ -1,0 +1,38 @@
+<div class="post-line">
+
+  {{ $dateFormat := "2 Jan 2006"}}
+  {{ with .Site.Params.listDateFormat }}
+    {{ $dateFormat = .}}
+  {{ end }}
+
+  <p class="line-date">{{ .Date | time.Format $dateFormat }} </p>
+
+  <div>
+      <p class="line-title">
+          <a href="{{ .RelPermalink }}">
+              {{ .Title }}
+          </a>
+      </p>
+
+      <div class="category-tags">
+        {{ $categories := .GetTerms "categories" }}
+        {{ if $categories }}
+          <a class="category" href="{{ (index $categories 0).RelPermalink }}">{{ (index $categories 0).LinkTitle }}</a>
+          &nbsp; · &nbsp;
+        {{ end }}
+
+        {{ $tags := .GetTerms "tags" }}
+        {{ if $tags }}
+          {{ range $i, $tag := $tags }}
+            {{- if $i }}&nbsp;{{ end -}}
+            <a class="tag" href="{{ $tag.RelPermalink }}">#{{ $tag.Name }}</a>
+          {{ end }}
+        {{ end }}
+      </div>
+
+      {{ if .Site.Params.listSummaries }}
+      <p class="line-summary"> {{ .Summary }} </p>
+      {{ end }}
+
+  </div>
+</div>

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -58,7 +58,7 @@
             {{- range $index, $tag := . }}
             {{- with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
                 <span>
-                  <a href="{{ .Permalink }}">#{{ .LinkTitle }} <span class="tag-count">({{ len .RegularPages }})</span></a>
+                  <a href="{{ .Permalink }}">#{{ .Name }} <span class="tag-count">({{ len .RegularPages }})</span></a>
                 </span>
             {{- end }}
             {{- end }}


### PR DESCRIPTION
## Summary
- Added tags and categories display to front page post listings
- Updated post entry template to show category and tags for each post
- Enhanced styling for tags and categories in post listings
- Improved blog configuration with better title and date formatting
- Added Prettier configuration for Go template formatting
- Created HTML improvement recommendations document

## Test plan
- [x] Verify tags and categories appear on front page
- [x] Test styling of category and tag links
- [x] Confirm proper date formatting
- [x] Validate Hugo site builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)