### PR TITLE
SEO: sitemap & robots (with canonical URLs)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,8 +1,13 @@
-baseURL: "https://cstalhem.github.io"
+baseURL: "https://cstalhem.github.io/"
+canonifyURLs: true
 languageCode: "en-us"
 title: "Carl's Blog"
 theme: "typo"
 timeZone: "Europe/Stockholm"
+sitemap:
+  changefreq: "weekly"
+  filename: "sitemap.xml"
+  priority: 0.5
 
 params:
   description: "A blog to keep track of things i do, learn, and want to remember"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://cstalhem.github.io/sitemap.xml


### PR DESCRIPTION
Enable sitemap.xml and robots.txt via Hugo config; turn on canonifyURLs. Adds optional custom robots.txt.

------
https://chatgpt.com/codex/tasks/task_b_68952cf1900c83278a70c863cf4230d3